### PR TITLE
New repo for spock in gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,15 +17,14 @@ subprojects {
     apply plugin: 'groovy'
 
     repositories {
-        mavenRepo url: "http://m2repo.spockframework.org/snapshots"
-        mavenRepo url: "http://repository.codehaus.org/"
+        mavenRepo url: "https://jcenter.bintray.com"
         mavenCentral()
     }
 
     dependencies {
         groovy "org.codehaus.groovy:groovy-all:1.8.0"
         testCompile 'junit:junit:4.8.1'
-        testCompile('org.spockframework:spock-core:0.6-groovy-1.8-SNAPSHOT') {
+        testCompile('org.spockframework:spock-core:0.6-groovy-1.8') {
             exclude module: 'groovy-all'
         }
     }


### PR DESCRIPTION
Repo http://m2repo.spockframework.org/snapshots does not exist anymore. Use JCenter instead.
